### PR TITLE
[bug] Dynamically getting current year

### DIFF
--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -54,7 +54,7 @@ export interface IDatePickerProps {
 
 const DatePicker = ({
   minYear = 1900,
-  maxYear = 2020,
+  maxYear = new Date().getFullYear(),
   initialDate = new Date(),
   onConfirm,
 }: IDatePickerProps) => {
@@ -64,6 +64,7 @@ const DatePicker = ({
   const year = useRef(initialDate.getUTCFullYear());
   const hours = useRef(initialDate.getHours());
   const minutes = useRef(initialDate.getUTCMinutes());
+
   const [dayValues] = useState(
     getDayValues(daysInMonth(year.current, month.current))
   );


### PR DESCRIPTION
**Issue:** When populating date picker with a set of years, we had hardcoded the maximum year to go up to as 2020 - now using **getFullYear** on the Date object to get the current year (this was causing an error when opening the Picker)